### PR TITLE
Allow users to add packages to LaTeX preamble 

### DIFF
--- a/code/tex3pt.ado
+++ b/code/tex3pt.ado
@@ -2,66 +2,72 @@ program tex3pt
 *! version 2.1.0 Derek Wolfson 17feb2016
 syntax anything(name=table id="tex table") using/, ///
 	[replace] [TITLE(string) TLABel(string) NOTE(string asis)] ///
-	[FONT(string) MATHFONT(string) FONTSIZE(string) CWIDTH(string) WIDE] /// OPTIONS REQ. SUBSEQUENT LOCALS
-	[PREamblea(str asis) PREambleb  ENDdoc PAGE LANDscape CLEARpage COMPile STARs(string) MARGins(string) RELATIVEpath(string) FLOATPLACEMENT(string)] //
+	[FONT(string) MATHFONT(string) FONTSIZE(string)  CWIDTH(string) WIDE] /// OPTIONS REQ. SUBSEQUENT LOCALS
+	[PREamblea(str asis) PREambleb  ENDdoc PACKage(string) PAGE LANDscape CLEARpage COMPile STARs(string) MARGins(string) RELATIVEpath(string) FLOATPLACEMENT(string)] //
 
-version 12.1	
+version 12.1
 
 	**CREATE LOCALS FOR USING AND TABLE SINCE THEY WILL BE CLEARED BY SUBSEQ. SYNTAX CALLS*
 	local table1 : copy loc table
-	local using1 : copy loc using 
-	
+	local using1 : copy loc using
+
 	**IF PAGE IS SELECTED THEN TURN ON REPLACE PREAMBLE ENDDOC**
 	if "`page'"!=""{
 		local replace "replace"
 		local preambleb "preambleb"
 		local enddoc "enddoc"
 	}
-	
+
+	** ERROR if package is added without preamble
+	if "`package'"!="" & "`preambleb'"=="" & "`preamblea'"==""{
+	di as error "Syntax error: Must include option option -preamble- if option -package-  is selected"
+	exit 198
+	}
+
 	**CREATE ERROR IF COMPILE IS USED BUT ENDDOC IS NOT**
 	if "`compile'"!="" & "`enddoc'"==""{
 	di as error "Syntax error: Must include option -enddoc- if option -compile- is selected"
 	exit 198
 	}
-	
+
 	**CREATE ERROR IF PREAMBLE IS USED BUT REPLACE IS NOT**
 	if "`preamblea'"!="" & "`replace'"==""{
 	di as error "Syntax error: Must include option -replace- if option -preamble- is selected"
 	exit 198
 	}
-	
+
 	if "`preambleb'"!="" & "`replace'"==""{
 	di as error "Syntax error: Must include option -replace- if option -preamble- is selected"
 	exit 198
 	}
-	
+
 	**CREATE ERROR IF MFONT OR FONT IS USED BUT PREAMBLE IS NOT**
 	if "`preamblea'"=="" & "`preambleb'"=="" & "`font'"!="" & "`mfont'"!=""{
 	di as error "Syntax error: Must include option -preamble- if option -font- or -mfont- is selected"
 	exit 198
 	}
-	
+
 	if "`preamblea'"=="" & "`preambleb'"=="" & "`font'"!=""{
 	di as error "Syntax error: Must include option -preamble- if option -font- is selected"
 	exit 198
 	}
-	
+
 	if "`preamblea'"=="" & "`preambleb'"=="" & "`mfont'"!=""{
 	di as error "Syntax error: Must include option -preamble- if option -mfont- is selected"
 	exit 198
 	}
-	
-	
+
+
 	**PREAMBLE OPTIONS**
 		**LIST: INCLUDE LIST OF TABLES AT TOP OF DOCUMENT**
-		local list = regexm("`preamblea'", "list")		
+		local list = regexm("`preamblea'", "list")
 			if `list'==0{
 				local listtablelist ""
-			}		
+			}
 			if `list'==1{
 			local listtablelist "\listoftables\clearpage"
 			}
-		
+
 		*FOOTER: INFORMATION ABOUT CREATOR AND CREATION DATE
 		local footer = regexm("`preamblea'", "info")
 		if `footer'==0 & `list'==1{
@@ -75,13 +81,13 @@ version 12.1
 		if "`preamblea'"!=""{
 			local preambleb preambleb
 		}
-		
-		
-	
+
+
+
 	**FONT OPTION**
 	loc 0 : copy loc font
 	syntax [anything(name=fontname)], [FOPT(string)]
-	
+
 		if "`fontname'"==""{
 			local textfont `"%DEFAULT"'
 		}
@@ -92,11 +98,11 @@ version 12.1
 			local textfont `"\usepackage[`fopt']{`fontname'}"'
 		}
 	**END FONT OPTION**
-	
+
 	**MFONT OPTION**
 	loc 0 : copy loc mathfont
 	syntax [anything(name=mfontname)], [MFOPT(string)]
-	
+
 		if "`mfontname'"==""{
 			local mfont `"%DEFAULT"'
 		}
@@ -107,7 +113,7 @@ version 12.1
 			local mfont `"\usepackage[`mfopt']{`mfontname'}"'
 		}
 	**END MFONT OPTION**
-	
+
 version 12.1
 
 **OPTIONS STORED IN LOCALS**
@@ -117,6 +123,14 @@ version 12.1
 	}
 	else{
 	local MARGINSIZE  "1.5cm"
+	}
+
+	**Package**
+	if "`package'"!=""{
+	local PACKAGELIST  "`package'"
+	}
+	else{
+	local PACKAGELIST  ""
 	}
 
 	**FONTSIZE OPTION**
@@ -153,7 +167,7 @@ version 12.1
 			local mathfont "\usepackage[`mathchoice2']{`mathchoice1'}"
 		}
 	**END M(ath)FONT OPTION**
-	
+
 	**TABLE LABEL OPTION**
 	if "`tlabel'"==""{
 		local tablelabel ""
@@ -164,7 +178,7 @@ version 12.1
 	**END TABLE LABEL OPTION**
 
 
-	
+
 	**C(olumn) WIDTH*
 	if "`cwidth'"==""{
 		local columnwidth = ""
@@ -172,7 +186,7 @@ version 12.1
 	else{
 		local columnwidth = ",table-column-width=`cwidth'"
 	}
-	
+
 	**STARS**
 	if "`stars'"==""{
 		local starnote ""
@@ -196,7 +210,7 @@ version 12.1
 	}
 
 	**END STARS**
-	
+
 	**WIDE TABLE**
 	if "`landscape'"==""{
 		if "`wide'"!=""{
@@ -214,35 +228,35 @@ version 12.1
 			local outputtype "auto"
 		}
 	}
-	
+
 **CHANGE \ to / FOR LATEX INPUT**
 	local table1: subinstr local table1 "\" "/", all
 	local using1: subinstr local using1 "\" "/", all
-	
+
 **CHANGE LOCALS TO NOT INCLUDE .tex**
 	local using1: subinstr local using1 ".tex" "", all
 	local table1: subinstr local table1 ".tex" "", all
 	local table1: subinstr local table1 `"""' "", all
 	local table1 "`table1'.tex"
 
-	
-**CREATE LOCAL FOR NUMBER OF COLUMNS & NUMBER OF DIGITS BEFORE AND AFTER DECIMAL POINT** 
+
+**CREATE LOCAL FOR NUMBER OF COLUMNS & NUMBER OF DIGITS BEFORE AND AFTER DECIMAL POINT**
 	get_params, table("`table1'")
 	loc NUMBEROFCOLUMNS = r(NUMBEROFCOLUMNS)
 	loc N_ALIGN = `NUMBEROFCOLUMNS'+1
 	*loc DIGITSBEFOREDECIMAL = r(COUNT1)
 	*loc DIGITSAFTERDECIMAL = r(COUNT2)
-	
+
 	forvalues i = 2 / `N_ALIGN'{
 	loc DBEFOREDEC	= r(COL`i'_C1)
 	local DAFTERDEC = r(COL`i'_C2)
-		if r(COL`i'_STARS) == 3{ 
+		if r(COL`i'_STARS) == 3{
 			local STARSPACE = ",table-space-text-post=***"
 		}
-		else if r(COL`i'_STARS) == 2{ 
+		else if r(COL`i'_STARS) == 2{
 			local STARSPACE = ",table-space-text-post=**"
 		}
-		else if r(COL`i'_STARS) == 1{ 
+		else if r(COL`i'_STARS) == 1{
 			local STARSPACE = ",table-space-text-post=*"
 		}
 		else{
@@ -250,15 +264,15 @@ version 12.1
 		}
 	local COLALIGN `COLALIGN' S[table-format=`DBEFOREDEC'.`DAFTERDEC' `STARSPACE' `columnwidth']
 	}
-	
-	
+
+
 **CREATE WORKING DIRECTORY LOCALS**
 	*CURRENT DIRECTORY*
 	local CWD "`c(pwd)'"
 	*NEW WORKING DIRECTORY FOR LATEX*"
 	mata: st_local("NWD", parent_dir(st_local("using1")))
 
-/* REMOVED IN VERSION 
+/* REMOVED IN VERSION
 **SUBSTITUTE SPECIAL LATEX CHARACTERS** NOT WORKING FIX THIS LATER
 foreach string in title note{
 		local `string': subinstr local `string' "\" "\text{\}", all
@@ -282,10 +296,10 @@ while "``token''" != "" {
  }
  local ++token
 }
-	
+
 **DEFINE TEMPNAME FOR FILE HANDLE**
 tempname tex_file
-**REPLACE OR APPEND**	
+**REPLACE OR APPEND**
 cap file close `tex_file'
 
 	if "`replace'"!=""{
@@ -297,7 +311,7 @@ cap file close `tex_file'
 
 	file open `tex_file' using "`using1'.tex", write `REPLACEORAPPEND'
 	file close `tex_file'
-	
+
 *WRITE PREAMBLE IF OPTION IS ON**
 	if "`preambleb'"!=""{
 	file open `tex_file' using "`using1'.tex", write append
@@ -311,10 +325,15 @@ cap file close `tex_file'
 	`"\usepackage[margin=`MARGINSIZE']{geometry}"' _n /// USES MARGINSIZE MACRO
 	`"\usepackage{dcolumn}"' _n ///
 	`"\usepackage{comment}"' _n ///
-	`"\usepackage{fancyhdr}"' _n 
-	
-	
-	if `footer' == 1{ 
+	`"\usepackage{fancyhdr}"' _n
+	if "`PACKAGELIST'"!=""{
+		foreach pack of local PACKAGELIST{
+			file write `tex_file' ///
+			`"\usepackage{`pack'}"' _n
+		}
+	}
+
+	if `footer' == 1{
 		file write `tex_file' ///
 	`" \fancypagestyle{firststyle}"' _n ///
      "  { " _n ///
@@ -322,9 +341,9 @@ cap file close `tex_file'
      "   \renewcommand{\headrulewidth}{0pt}" _n ///
      "   \fancyfoot[L]{Created by: `c(username)'}" _n ///
      "   \fancyfoot[R]{Created on: `c(current_date)' `c(current_time)'}" _n ///
-     "  }" _n _n 
+     "  }" _n _n
 	 } //end if footer==1
-	 
+
 
 		file write `tex_file' ///
 	`"% Necessary packages"' _n ///
@@ -444,7 +463,7 @@ cap file close `tex_file'
 	"% The new approach using threeparttables to generate notes that are the exact width of the table." _n ///
 	"\newcommand{\Figtext}[1]{%" _n ///
 	"	\begin{tablenotes}[para,flushleft]" _n ///
-	"	{" _n /// 
+	"	{" _n ///
 	"	#1" _n ///
 	"	}" _n ///
 	"	\end{tablenotes}" _n ///
@@ -458,7 +477,7 @@ cap file close `tex_file'
 	"`listtablelist'" _n _n _n _n ///
 	"%=================================================%" _n ///
 	"%============BEGIN TABLE OUTPUT===================%" _n ///
-	"%=================================================%" _n 
+	"%=================================================%" _n
 	file close `tex_file'
 	}
 ***END PREAMBLE***
@@ -476,24 +495,24 @@ file write `tex_file' ///
 	file write `tex_file' ///
 		"\begin{landscape}" _n _n
 	}
-	
+
 	**USE RELATIVE PATH FOR TABLE REFERENCE**
 	if "`relativepath'"!=""{
 		_getfilename "`table1'"
 		local table1 "`relativepath'`r(filename)'"
 	}
-	
+
 	**CREATE FLOAT PLACEMENT MACRO
 	if "`floatplacement'" != ""{
 		local fplace "[`floatplacement']"
 	}
 	else{
-		local fplace "" 
+		local fplace ""
 	}
-	
+
 	file write `tex_file' ///
 		"\begin{table}`fplace'\centering""`fontsizechoice'" _n 								/// USES FONT SIZE MACRO HERE & FLOAT PLACEMENT
-		"  \begin{threeparttable}" _n ///	
+		"  \begin{threeparttable}" _n ///
 		"    \caption{`tablelabel'`macval(title)'} %%TABLE TITLE" _n 						/// USES TITLE MACRO HERE
 		`"    \est`outputtype'{"`table1'"}{`NUMBEROFCOLUMNS'}{`COLALIGN'}"' _n 	/// MACROS: OUTPUTTYPE DIGITSAFTER(BEFORE)DECIMAL COLUMNWIDTH
 		`"	`macval(starnote)' "' _n														/// USES STARNOTE MACRO HERE
@@ -503,13 +522,13 @@ file write `tex_file' ///
 			file write `tex_file' ///
 		`"\Figtext{{`notefontsize' `macval(note`i')'}} %%TABLE NOTE"' _n 										// USES NOTE & NOTEFONTSIZE MACRO HERE
 			}
-			
+
 	**FINISH TABLE**
 		file write `tex_file' ///
 			"  \end{threeparttable}" _n ///
-		"\end{table}" _n  
+		"\end{table}" _n
 	file close `tex_file'
-			
+
 
 	**INCLUDE LANDSCAPE CLOSURE
 		if "`landscape'"!=""{
@@ -545,7 +564,7 @@ file write `tex_file' ///
 
 	**COMPILE COMPLETED TEX DOCUMENT** (THANKS RAYMOND)
 	if "`compile'"!=""{
-		if "`c(os)'" == "Windows" | "`c(os)'" == "MacOSX" { 
+		if "`c(os)'" == "Windows" | "`c(os)'" == "MacOSX" {
 			qui cd "`NWD'"
 			cap rm "`using1'.pdf"
 			*run pdflatex twice for hyperref
@@ -553,7 +572,7 @@ file write `tex_file' ///
 				!pdflatex "`using1'.tex" & pdflatex "`using1'.tex"
 			}
 			else if "`c(os)'" == "MacOSX" {
-				!PATH=\$PATH:/usr/local/bin:/usr/texbin ///
+				!PATH=\$PATH:/usr/local/bin:/usr/texbin:/Library/TeX/texbin ///
 					&& pdflatex "`using1'".tex ///
 					&& pdflatex "`using1'".tex
 			}
@@ -563,7 +582,7 @@ file write `tex_file' ///
 			cap rm "`using1'.lot"
 			cap rm "`using1'.out"
 			cap rm "`using1'.ttt"
-			
+
 			*.tex and .pdf messages
 			di as txt `"(TEX output written to {browse "`using1'.tex"})"'
 			cap confirm file "`using1'.pdf"
@@ -574,7 +593,7 @@ file write `tex_file' ///
 			di as txt `"(PDF output written to {browse "`using1'.pdf"})"'
 			}
 			*change directory back to original
-			qui cd "`CWD'"				
+			qui cd "`CWD'"
 		}
 
 		else {
@@ -588,11 +607,11 @@ file write `tex_file' ///
 	}
 end
 
-**PROGRAM FOR GETTING COLUMN NUMBRS AND DIGITS BEFORE/AFTER 
+**PROGRAM FOR GETTING COLUMN NUMBRS AND DIGITS BEFORE/AFTER
 pr get_params, rclass
 syntax, table(str)
 quietly{
-preserve 
+preserve
 	cap which chewfile
 	if _rc!=0{
 	di as error "Tex3pt requires the SSC command chewfile." _n ///
@@ -605,13 +624,13 @@ ret sca NUMBEROFCOLUMNS = c(k)-1
 
 **CREATE VARIABLE FOR MAX NUMBER OF STARS PER COLUMN**
 forv i=2/`c(k)'{
-gen star`i' = . 
+gen star`i' = .
 	replace star`i' = 1 if regexm(var`i',"\\sym{\*}")
 	replace star`i' = 2 if regexm(var`i',"\\sym{\*\*}")
 	replace star`i' = 3 if regexm(var`i',"\\sym{\*\*\*}")
 }
 forv i = 2/`NUM'{
-qui sum star`i' 
+qui sum star`i'
 ret sca COL`i'_STARS = r(max)
 }
 
@@ -630,7 +649,7 @@ forvalues i = 2/`NUM'{
 	tab n`i'
 	if r(N)==0{
 		ret sca COL`i'_C1 = 1
-		ret sca COL`i'_C2 = 0 
+		ret sca COL`i'_C2 = 0
 	}
 	else{
 		qui split n`i', parse(.) gen(s`i')

--- a/code/tex3pt.sthlp
+++ b/code/tex3pt.sthlp
@@ -9,7 +9,7 @@
 {title:Title}
 
 {phang}
-{bf:tex3pt} {hline 2} creates LaTeX documents from {cmd:esttab} output using the LaTeX package threeparttable.  
+{bf:tex3pt} {hline 2} creates LaTeX documents from {cmd:esttab} output using the LaTeX package threeparttable.
 
 
 {marker syntax}{...}
@@ -39,6 +39,7 @@
 
 {syntab:LaTeX Document Options}
 {synopt:{opt pre:amble}[({it:options})]} write .tex preamble {p_end}
+{synopt:{opt pack:age}({it:packagelist})} adds user specified LaTeX packages to the preamble {p_end}
 {synopt:{opt replace}} replace .tex file {p_end}
 {synopt:{opt end:doc}} write \end{document} at the end of the .tex file {p_end}
 {synopt:{opt page}} equivalent to specifying the options preamble, replace and enddoc {p_end}
@@ -55,9 +56,9 @@
 {title:Description}
 
 {pstd}
-{cmd:tex3pt} takes .tex output from {cmd:esttab} and writes it into a LaTeX file using threeparttable. This 
-greatly improves the level of compatibility between LaTeX and {cmd:esttab}.  Since this program uses the LaTeX package threeparttable 
-the notes and title of the table will not bleed beyond the width of the table.  Multiple calls of {cmd:tex3pt} allows the user 
+{cmd:tex3pt} takes .tex output from {cmd:esttab} and writes it into a LaTeX file using threeparttable. This
+greatly improves the level of compatibility between LaTeX and {cmd:esttab}.  Since this program uses the LaTeX package threeparttable
+the notes and title of the table will not bleed beyond the width of the table.  Multiple calls of {cmd:tex3pt} allows the user
 to compile many tables in a single LaTeX document easily.
 
 {marker options}{...}
@@ -66,57 +67,57 @@ to compile many tables in a single LaTeX document easily.
 {dlgtab:Table-Specific Options}
 
 {phang}
-{opt title}{bf:({it:string})} takes a string argument and inserts it 
-as the title of the table. For example title(table title) 
-will insert \caption{table title} inside the threeparttable environment. 
+{opt title}{bf:({it:string})} takes a string argument and inserts it
+as the title of the table. For example title(table title)
+will insert \caption{table title} inside the threeparttable environment.
 
 {phang}
-{opt tlab:el}{bf:({it:string})} takes a string argument and inserts it 
-as the label for the the table in LaTeX.  For example, tlabel(table1) will 
+{opt tlab:el}{bf:({it:string})} takes a string argument and inserts it
+as the label for the the table in LaTeX.  For example, tlabel(table1) will
 insert \label{table1} within the \caption{} command.
 
 {phang}
-{opt note}{bf:({it:string})}  takes a string argument and inserts it as a note 
+{opt note}{bf:({it:string})}  takes a string argument and inserts it as a note
 below the table in LaTeX.  The notes will be typeset in \footnotesize unless
-size \scriptsize or \tiny is specified in the option fontsize.  If one of these 
-sizes is selected then the table notes will be typeset in \scriptsize or \tiny, respectively. 
-To force a line break in the notes insert a comma between notes.  For example, 
+size \scriptsize or \tiny is specified in the option fontsize.  If one of these
+sizes is selected then the table notes will be typeset in \scriptsize or \tiny, respectively.
+To force a line break in the notes insert a comma between notes.  For example,
 note("note1", "note2") will insert note1 on one line and note2 on a separate line.
-Your notes must be enclosed in quote if they contain a comma.  For example note("Hello,","Mister") will 
-insert Hello, on one line and Mister on a separate line.   
+Your notes must be enclosed in quote if they contain a comma.  For example note("Hello,","Mister") will
+insert Hello, on one line and Mister on a separate line.
 
 {phang}
-{opt star:s}{bf:({it:startype})}  displays the standard p-value significance 
-stars note at the bottom of the table.  You must specify {it:startype} 
-as either ols, robust or cluster clustervariable. Specifying stars(ols) 
-will add the following note to the bottom of the table: Standard errors 
+{opt star:s}{bf:({it:startype})}  displays the standard p-value significance
+stars note at the bottom of the table.  You must specify {it:startype}
+as either ols, robust or cluster clustervariable. Specifying stars(ols)
+will add the following note to the bottom of the table: Standard errors
 in parentheses. * p<.10 ** p<.05 *** p<.01. Specifying stars(robust) will
-add the following note to the bottom of the table: Heteroskedasticity-robust 
-standard errors in parentheses * p<.10 ** p<.05 *** p<.01.  Specifying 
-stars(cluster village) will add the following note to the bottom of the table: 
+add the following note to the bottom of the table: Heteroskedasticity-robust
+standard errors in parentheses * p<.10 ** p<.05 *** p<.01.  Specifying
+stars(cluster village) will add the following note to the bottom of the table:
 Standard errors clustered by village in parentheses. * p<.10 ** p<.05 *** p<.01.
 {it:Note}: This option does not support t-values, brackets other than parentheses or
-other significance levels. If you need a custom note for significance levels, 
+other significance levels. If you need a custom note for significance levels,
 you may add it to the note option for your table.
 
 {phang}
 {opt fontsize}{bf:({it:size})} sets the size of the text for the table.  You must specify
 size as one of the standard LaTeX text sizes.  In ascending order the available text
-sizes are tiny, scriptsize, footnotesize, small, normalsize, large, Large, LARGE, 
+sizes are tiny, scriptsize, footnotesize, small, normalsize, large, Large, LARGE,
 huge, Huge.  If the fontsize option is not defined then \normalsize is used.
 
 {phang}
 {opt cwidth}{bf:({it:width})} sets the width of all columns in the table.  You must specify
-a {it:width} that LaTeX understands, such as 15mm or 1.5in. If cwidth is not defined 
-then {cmd:tex3pt} will set the column width automatically. 
+a {it:width} that LaTeX understands, such as 15mm or 1.5in. If cwidth is not defined
+then {cmd:tex3pt} will set the column width automatically.
 
 {phang}
 {opt wide} sets the width of the table to the linewidth of your document. This
-option automatically spaces the columns. Wide overrides the option cwidth. If both 
+option automatically spaces the columns. Wide overrides the option cwidth. If both
 cwidth and wide are not specified then {cmd:tex3pt} will set the column width automatically.
 
 {phang}
-{opt land:scape} writes the table on a landscape page using the \begin{landscape} and 
+{opt land:scape} writes the table on a landscape page using the \begin{landscape} and
 \end{landscape} tags included by the LaTeX package pdflscapes.
 
 {phang}
@@ -125,22 +126,25 @@ For example, floatplacement(!htbp) creates \begin{table}[!htbp]. If this option 
 
 {phang}
 {opt clear:page} forces LaTeX to clear the page after the table is written to the document.
-This writes the command \clearpage after the table is inserted to the document. Specifying 
-the clearpage option after every call of tex3pt will allow the user to force the document 
+This writes the command \clearpage after the table is inserted to the document. Specifying
+the clearpage option after every call of tex3pt will allow the user to force the document
 to have only one table per page.
 
 {dlgtab:LaTeX Document Options}
 
 {phang}
 {opt pre:amble}{bf:[{it:suboptions}]} writes the preamble required to use the {cmd:esttab} output in the
-LaTeX document that {cmd:tex3pt} writes. You must specify the option replace if you specify the option preamble. 
-The {it:suboptions} include {it:list} and {it:info}.  The {it:list} suboption will include a list of tables 
-(with hyperlinks) as the first page of the document. The {it:info} will write who created 
+LaTeX document that {cmd:tex3pt} writes. You must specify the option replace if you specify the option preamble.
+The {it:suboptions} include {it:list} and {it:info}.  The {it:list} suboption will include a list of tables
+(with hyperlinks) as the first page of the document. The {it:info} will write who created
 the document and when the document was created in the first page footer.  The {it:info} suboption requires that you
 also specify the {it:list} suboption.
 
 {phang}
-{opt replace} permits {cmd:tex3pt} to overwrite the {it:using} file.  If replace is not specified then 
+{opt pack:age}{bf:({it:packagelist})} Adds LaTeX packages from packagelist to the preamble. You must specify the option preamble if you specify the option package.
+
+{phang}
+{opt replace} permits {cmd:tex3pt} to overwrite the {it:using} file.  If replace is not specified then
 {cmd:tex3pt} appends to the {it:using} file.
 
 {phang}
@@ -153,13 +157,13 @@ for convenience in the case the user wants to create a self-contained .tex docum
 {phang}
 {opt comp:ile} compiles the .tex file into a .pdf.  This option opens the shell and runs pdflatex.
 This option requires that the option {it:enddoc} or {it:page} is also called.  This option all cleans up
-any auxilary files created by pdflatex so that only the .tex and .pdf file remain. This option only works on Windows 
+any auxilary files created by pdflatex so that only the .tex and .pdf file remain. This option only works on Windows
 and OS X.
 
 {phang}
-{opt marg:ins}{bf:({it:size})} sets the margins for the document.  The default margins are 1.5cm to allow 
-for extra space for tables.  This option sets all margins to the same value (i.e. top, bottom, left, right) 
-using the LaTeX package geometry.  For example, specifying the option margins(1in) will set all margins to 
+{opt marg:ins}{bf:({it:size})} sets the margins for the document.  The default margins are 1.5cm to allow
+for extra space for tables.  This option sets all margins to the same value (i.e. top, bottom, left, right)
+using the LaTeX package geometry.  For example, specifying the option margins(1in) will set all margins to
 one inch.  The user must specify a {it:size} that LaTeX understands, such as 15mm or 1.5in.
 
 {phang}
@@ -170,25 +174,25 @@ same folder to find the .tex table produced by {cmd:esttab}.  An absolute path i
 
 {phang}
 {opt font}{bf:({it:fontpackage}[, fopt({it:packageoptions})])} sets the text font for the document.
-For example, the option font(lmodern) will set the font of your document to Latin Modern by writing 
-\usepackage{lmodern} to the preamble.  The option font(comfortaa, fopt(default)) will set the 
-font to Comfortaa with the default option by writing \usepackage[default]{comfortaa} to the preamble.  
+For example, the option font(lmodern) will set the font of your document to Latin Modern by writing
+\usepackage{lmodern} to the preamble.  The option font(comfortaa, fopt(default)) will set the
+font to Comfortaa with the default option by writing \usepackage[default]{comfortaa} to the preamble.
 If the option font is not specified then the document will use the default LaTeX font.
 
 {phang}
-{opt mathfont}{bf:({it:mathfontpackage}[, mfopt({it:packageoptions})])} sets the math font 
+{opt mathfont}{bf:({it:mathfontpackage}[, mfopt({it:packageoptions})])} sets the math font
 for the document. For example, the option mathfont(eulervm) will set the math font of your document to Euler
-Virtual Math by writing \usepackage{eulervm} to the preamble.  The option mathfont(eulervm, mfopt(small, euler-digits)) 
+Virtual Math by writing \usepackage{eulervm} to the preamble.  The option mathfont(eulervm, mfopt(small, euler-digits))
 will set the math font to Euler Virtual Math using the small and euler-digits options by writing
-\usepackage[small, euler-digits]{eulervm} to the preamble.  If the option font is not specified the default 
+\usepackage[small, euler-digits]{eulervm} to the preamble.  If the option font is not specified the default
 LaTeX math font Computer Modern is used.
 
 {dlgtab:\specialcell{} syntax}
 
 {pstd}
 The LaTeX preamble that this command writes includes the user-written LaTeX command \specialcell{}.  With \specialcell{} you can specify line breaks.
-This is especially helpful when you want to have complex column titles.  For example if you define a column title in {cmd:esttab} as "Foreign Cars (Non-Rotary)" 
-it will be problematic for LaTeX since it will not add any line in the column title.  You can get around this by using the \specialcell{} syntax. The correct syntax for 
+This is especially helpful when you want to have complex column titles.  For example if you define a column title in {cmd:esttab} as "Foreign Cars (Non-Rotary)"
+it will be problematic for LaTeX since it will not add any line in the column title.  You can get around this by using the \specialcell{} syntax. The correct syntax for
 the column title above is \specialcell{Foreign Cars \\ (Non-Rotary)}.  \specialcell{} will create a column title with line breaks defined at each "\\".
 Example 2.1 uses this syntax.
 
@@ -196,53 +200,53 @@ Example 2.1 uses this syntax.
 {title:Remarks}
 
 {pstd}
-This package is intended to work with {cmd:esttab}.  If you do not have this packages use 
+This package is intended to work with {cmd:esttab}.  If you do not have this packages use
 {stata ssc install estout:ssc install estout} to install the {cmd:estout} package (which includes {cmd:esttab}).
 
 {pstd}
-To use this package with {cmd:esttab} output you must supply the options {it:booktabs fragment} or {it:tex fragment} to {cmd:esttab}.  
-This is the format that {cmd:tex3pt} expects, and it will not work otherwise. This package is not currently compatible with the 
+To use this package with {cmd:esttab} output you must supply the options {it:booktabs fragment} or {it:tex fragment} to {cmd:esttab}.
+This is the format that {cmd:tex3pt} expects, and it will not work otherwise. This package is not currently compatible with the
 LaTeX package longtable, however a solution is in the works.
 
 {pstd}
 This package extracts all the necessary input directly from the .tex file it is inputting, so there is no
-need to run {cmd:tex3pt} right after your {cmd:esttab} calls.  The key component of this program is 
+need to run {cmd:tex3pt} right after your {cmd:esttab} calls.  The key component of this program is
 writing the following in a .tex document: \estauto{{it:table}}{{it:#1}}{S[table-format={it:#2}.{it:#3} ]}
-where {it:table} is the file that you created using {cmd:esttab}, {it:#1} is the number of columns in your table not 
+where {it:table} is the file that you created using {cmd:esttab}, {it:#1} is the number of columns in your table not
 including the first column of variable names, {it:#2} is the maximum number of digits before the decimal
 point in your table and {it:#3} is the maximum number of digits after the decimal point in your table. These
-parameters are key to creating a nicely aligned table.  This program extracts these parameters 
+parameters are key to creating a nicely aligned table.  This program extracts these parameters
 from the raw .tex input and the {cmd:tex3pt} call.{p_end}
 
 {pstd}
-{cmd:Tex3pt} was specifically set up to deal with regressions, so if we use it for tabulation or 
-summary statistics tables we have to ensure that the text for the column headers are encased in the 
+{cmd:Tex3pt} was specifically set up to deal with regressions, so if we use it for tabulation or
+summary statistics tables we have to ensure that the text for the column headers are encased in the
 environment "\multicolumn{#}{c}{{it:columnheaders}}".  You can do this by using the prefix and suffix options
-for the {bf:collabel} and {bf:eqlabel} options for {cmd:esttab}.  See the examples for usage of the prefix and 
+for the {bf:collabel} and {bf:eqlabel} options for {cmd:esttab}.  See the examples for usage of the prefix and
 suffix options in {cmd:esttab}.
 
 {pstd}
-Since the .ado depends on the siunitx package for LaTeX the table output from {cmd:esttab} cannot 
-contain commas.  Siunitx treats commas as a protected characters in table mode.  You can remove the 
-commas from your output by simply including the option substitute("," "") in {cmd:esttab}.  
+Since the .ado depends on the siunitx package for LaTeX the table output from {cmd:esttab} cannot
+contain commas.  Siunitx treats commas as a protected characters in table mode.  You can remove the
+commas from your output by simply including the option substitute("," "") in {cmd:esttab}.
 
 {pstd}
-As of Version 2.0.5, this package {bf:no longer} replaces special LaTeX characters like "$" with "\$" in the {it:notes} and {it:title} strings to 
+As of Version 2.0.5, this package {bf:no longer} replaces special LaTeX characters like "$" with "\$" in the {it:notes} and {it:title} strings to
 avoid errors. {p_end}
 
 {marker examples}{...}
 {title:Examples}
 
 {pstd}
-The following examples assume that the user knows how to use {cmd:esttab} fairly well.  
-See {helpb esttab} or {helpb estout} if you want to understand the options 
-used for {cmd:esttab} in these examples. I also suggest you read 
+The following examples assume that the user knows how to use {cmd:esttab} fairly well.
+See {helpb esttab} or {helpb estout} if you want to understand the options
+used for {cmd:esttab} in these examples. I also suggest you read
 {browse "http://repec.org/bocode/e/estout/esttab.html#esttab012":using LaTeX with esttab}
 and {browse "http://repec.org/bocode/e/estout/advanced.html#advanced500":advanced LaTeX with esttab}.
 
 {pstd}
-{bf: Note:} These examples will store estimates and create .tex and .pdf files in your working directory.  
-I suggest you start with empty Stata instance and change your directory to somewhere familiar so 
+{bf: Note:} These examples will store estimates and create .tex and .pdf files in your working directory.
+I suggest you start with empty Stata instance and change your directory to somewhere familiar so
 you may find and remove these files.
 
 	{pmore}
@@ -254,12 +258,12 @@ you may find and remove these files.
 		sysuse auto
 		replace price=price/1000
 
-		qui eststo example111: reg price mpg weight 
+		qui eststo example111: reg price mpg weight
 		qui eststo example112: reg price mpg weight headroom trunk length
 		qui eststo example113: reg price mpg weight i.foreign
 		qui eststo example114: reg price mpg weight headroom trunk length i.foreign
 
-		esttab example11* using "test11", /// 
+		esttab example11* using "test11", ///
 			replace fragment booktabs ///
 			label b(3) se(3) se ///
 			star(* .1 ** .05 *** .01) ///
@@ -274,7 +278,7 @@ you may find and remove these files.
 			 layout("\multicolumn{1}{c}{@}" "\multicolumn{1}{c}{@}") ///
 			 labels("R-Sq" "Observations") ///
 			) // end stats
-			
+
 		tex3pt "test11.tex" using "master11.tex", ///
 			page ///
 			clearpage compile ///
@@ -282,17 +286,17 @@ you may find and remove these files.
 			tlabel("tab1") ///
 			star(ols) ///
 			note("This is a note in tex3pt!")
-	
+
 	{pmore}
 	{bf:{ul:Example 1.2 - Regression Output, Multiple Tables}}{p_end}
 	{pmore}
 	{it:Copy the text below into a do-file editor and run this code to output a document with two tables and a list on the first page using {cmd:tex3pt}:}
 	{p_end}
-	
-		sysuse auto 
+
+		sysuse auto
 		replace price=price/1000
 
-		qui eststo example121: reg price mpg weight 
+		qui eststo example121: reg price mpg weight
 		qui eststo example122: reg price mpg weight headroom trunk length
 		qui eststo example123: reg price mpg weight i.foreign
 		qui eststo example124: reg price mpg weight headroom trunk length i.foreign
@@ -319,7 +323,7 @@ you may find and remove these files.
 			 labels("R-Sq" "Observations") ///
 			) // end stats
 
-			
+
 
 		tex3pt "test121.tex" using "master12.tex", ///
 			preamble(list info)	replace  ///
@@ -343,8 +347,8 @@ you may find and remove these files.
 	{pmore}
 	{it:Copy the text below into a do-file editor and run this code to output a document with a table of summary statistics using {cmd:tex3pt}:}
 	{p_end}
-	
-		sysuse auto 
+
+		sysuse auto
 		replace price=price/1000
 
 		eststo example211: estpost summarize mpg rep78 foreign, listwise
@@ -363,7 +367,7 @@ you may find and remove these files.
 			compile ///
 			title("Summary Statistics")
 
-			
+
 	{pmore}
 	{bf:{ul:Example 3.1 - Tabulation Table}}{p_end}
 	{pmore}
@@ -371,7 +375,7 @@ you may find and remove these files.
 
 		sysuse auto
 		replace price=price/1000
-		
+
 		eststo example311: estpost tabulate rep78 foreign
 
 		esttab example311 using test311.tex, ///
@@ -384,7 +388,7 @@ you may find and remove these files.
 			  prefix(\multicolumn{@span}{c}{) ///
 			  suffix(}) ///
 			) /// end eqlabels
-			collabels("" "", /// 
+			collabels("" "", ///
 			  lhs("\multicolumn{1}{c}{Repair Record}") ///
 			) // end collabels
 
@@ -395,7 +399,7 @@ you may find and remove these files.
 
 		{pmore}
 		{bf:Note}: If your tabulation includes any values >=1000 they will be interpreted by {cmd:esttab} as "1,000".  Those commas will be problematic for the
-		alignment of table.  Add the option substitute("," "") to the {cmd:esttab} call to erase those commas.  
+		alignment of table.  Add the option substitute("," "") to the {cmd:esttab} call to erase those commas.
 
 
 {marker author}{...}
@@ -412,8 +416,8 @@ You can find the source code for this .ado file at {browse "https://github.com/d
 {marker acknowledgements}{...}
 {title:Acknowledgements}
 
-{pstd} 
+{pstd}
 I am extremely grateful to Jorg Weber and all the work he did in creating the wonderful preamble and LaTeX commands that this program uses.  You
-can find all that discourse {browse "http://goo.gl/D2GzNm":here}, {browse "http://goo.gl/iVa3wX":here} and {browse "http://goo.gl/YDv0hH":here}.  
+can find all that discourse {browse "http://goo.gl/D2GzNm":here}, {browse "http://goo.gl/iVa3wX":here} and {browse "http://goo.gl/YDv0hH":here}.
 I also tip my hat to Innovations for Poverty Action, Matt White, Nils Enevoldsen and Raymond Guiteras for help with the program.
 


### PR DESCRIPTION
This adds the option "package(packagelist)" to tex3pt. This option allows users to specify packages to include in the preamble.
An example for the use of the option are tables with checkmarks. For checkmarks to be displayed the user may want to include the \usepackage{"amssymb"}. This would be done with:
tex3pt table using filename , package(amssymb) preamb

It may be useful to change this functionality to allow the user to add more flexible input to the preamble.
